### PR TITLE
Save schema response to staticResponse during create & update

### DIFF
--- a/components/json-viewer.tsx
+++ b/components/json-viewer.tsx
@@ -139,7 +139,7 @@ export default function JsonViewer({ data, className }: JsonViewerProps) {
 
   return (
     <div className={cn("relative", className)}>
-      <div className="absolute top-2 right-2 z-10">
+      <div className="absolute top-3 right-5 z-10">
         <Button
           onClick={copyToClipboard}
           size="sm"

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -70,3 +70,12 @@ export function generateApiToken(): string {
   crypto.getRandomValues(array);
   return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
 };
+
+export function stringifyJSON (jsonData: any, space: number = 2): string {
+  try {
+    return JSON.stringify(jsonData, undefined, space);
+  } catch (error) {
+    console.error("Error stringifying JSON:", error);
+    return String(jsonData);
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Endpoint {
   description       String?
   method            HttpMethod       @default(GET)
   path              String
+  // TODO: change staticResponse to response, and cannot be null
   staticResponse    Json? // For hardcoded responses
   schemaId          Int?
   schema            Schema?          @relation(fields: [schemaId], references: [id])

--- a/services/endpoint.service.ts
+++ b/services/endpoint.service.ts
@@ -40,59 +40,27 @@ export class EndpointService {
 
   // display what the endpoint should return when user request the mock data
   static getEndpointResponse(endpoint: Endpoint, queryParams?: QueryParams) {
-    let response;
-    // WITH SCHEMA
-    if (endpoint.schemaId && endpoint.schema) {
-      response = SchemaService.generateResponseFromSchema(
-        endpoint.schema as Schema,
-        endpoint.isDataList,
-        endpoint.numberOfData ?? undefined
-      );
-      
-      // Apply query parameter processing only for list data
-      if (endpoint.isDataList && Array.isArray(response) && queryParams) {
-        const result = QueryParamsHelper.processData(response, queryParams);
-        response = result.data;
-        
-        // If pagination is applied, wrap response with pagination info
-        // if (result.pagination) {
-        //   response = {
-        //     data: result.data,
-        //     pagination: result.pagination
-        //   };
-        // }
-      }
-      
-      if (endpoint.responseWrapper) {
-        response = ResponseWrapperService.generateResponseWrapperJson({
-          response,
+    let response = endpoint.responseWrapper
+      ? ResponseWrapperService.generateResponseWrapperJson({
+          response: endpoint.staticResponse,
           wrapper: endpoint.responseWrapper,
-        });
-      }
+        })
+      : endpoint.staticResponse;
+
+    // Apply query parameter processing for static responses if it's an array
+    if (Array.isArray(response) && queryParams) {
+      const result = QueryParamsHelper.processData(response, queryParams);
+      response = result.data;
+
+      // If pagination is applied, wrap response with pagination info
+      // if (result.pagination) {
+      //   response = {
+      //     data: result.data,
+      //     pagination: result.pagination
+      //   };
+      // }
     }
-    // WITH STATIC RESPONSE
-    else {
-      response = endpoint.responseWrapper
-        ? ResponseWrapperService.generateResponseWrapperJson({
-            response: endpoint.staticResponse,
-            wrapper: endpoint.responseWrapper,
-          })
-        : endpoint.staticResponse;
-      
-      // Apply query parameter processing for static responses if it's an array
-      if (Array.isArray(response) && queryParams) {
-        const result = QueryParamsHelper.processData(response, queryParams);
-        response = result.data;
-        
-        // If pagination is applied, wrap response with pagination info
-        // if (result.pagination) {
-        //   response = {
-        //     data: result.data,
-        //     pagination: result.pagination
-        //   };
-        // }
-      }
-    }
+
     return response;
   }
 }


### PR DESCRIPTION
if endpoint using schema, it should save the schema-response to staticResponse field as well, so later if user call api, it can directly show the staticResponse, this can save alot of processing time